### PR TITLE
Exclude placeholder artifacts from 'assemble'

### DIFF
--- a/core/src/main/kotlin/com/gradleup/librarian/core/publishing.kt
+++ b/core/src/main/kotlin/com/gradleup/librarian/core/publishing.kt
@@ -110,8 +110,12 @@ fun Project.configurePublishing(
     }
   }
 
-  val releaseConfiguration = configurations.create(CONFIGURATION_RELEASE_DATE)
-  val snapshotConfiguration = configurations.create(CONFIGURATION_SNAPSHOT_DATE)
+  val releaseConfiguration = configurations.create(CONFIGURATION_RELEASE_DATE) {
+    it.isVisible = false
+  }
+  val snapshotConfiguration = configurations.create(CONFIGURATION_SNAPSHOT_DATE) {
+    it.isVisible = false
+  }
 
   tasks.named("publishAllPublicationsToSonatypeStagingRepository").apply {
     configure { task ->


### PR DESCRIPTION
Without this, calling `./gradlew build` executes `assembles`, which tries to build all artifacts and therefore publish to MavenCentral...