### PR TITLE
Bump to KGP 2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,14 @@
 [versions]
-kotlin = "2.1.21"
+kgp = "2.2.0"
 
 [libraries]
 coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
 maven-sympathy = "com.gradleup.maven-sympathy:maven-sympathy:0.0.2"
 dokkatoo = "dev.adamko.dokkatoo:dokkatoo-plugin:2.3.1"
-bcv = "org.jetbrains.kotlinx:binary-compatibility-validator:0.16.3"
 
 gradle-api = "dev.gradleplugins:gradle-api:8.8"
 agp = "com.android.tools.build:gradle:8.2.0"
-kgp = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
+kgp-runtime-min = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"
 clikt = "com.github.ajalt.clikt:clikt:3.5.0"
 mordant = "com.github.ajalt.mordant:mordant:2.7.1"
 inquirer = "com.github.kotlin-inquirer:kotlin-inquirer:0.1.0"
@@ -24,8 +23,8 @@ bouncycastle-pg = "org.bouncycastle:bcpg-jdk18on:1.78.1"
 google-auth = "com.google.auth:google-auth-library-oauth2-http:1.19.0"
 
 gratatouille-gradle-plugin = "com.gradleup.gratatouille:com.gradleup.gratatouille.gradle.plugin:0.0.10"
-ksp-gradle-plugin = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.1.21-2.0.2"
+ksp-gradle-plugin = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.2.0-2.0.2"
 librarian-gradle-plugin = "com.gradleup.librarian:librarian-gradle-plugin:0.0.10-SNAPSHOT-214f46e836207a529c92e078540643ad6acc3054"
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kgp" }
 nmcp = "com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin:1.0.1"
 

--- a/librarian-gradle-plugin/api/librarian-gradle-plugin.api
+++ b/librarian-gradle-plugin/api/librarian-gradle-plugin.api
@@ -71,7 +71,8 @@ public final class com/gradleup/librarian/gradle/Librarian {
 }
 
 public final class com/gradleup/librarian/gradle/Librarian$Companion {
-	public final fun module (Lorg/gradle/api/Project;)V
+	public final fun module (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun module$default (Lcom/gradleup/librarian/gradle/Librarian$Companion;Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun registerGcsTask (Lorg/gradle/api/Project;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/file/FileCollection;)V
 	public final fun root (Lorg/gradle/api/Project;)V
 	public final fun version (Ljava/lang/String;)Ljava/lang/String;
@@ -86,7 +87,8 @@ public final class com/gradleup/librarian/gradle/MavenKt {
 }
 
 public final class com/gradleup/librarian/gradle/ModuleKt {
-	public static final fun librarianModule (Lorg/gradle/api/Project;)V
+	public static final fun librarianModule (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun librarianModule$default (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract class com/gradleup/librarian/gradle/Plugin : org/gradle/api/Plugin {

--- a/librarian-gradle-plugin/build.gradle.kts
+++ b/librarian-gradle-plugin/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 Librarian.module(project)
 
 dependencies {
-  api(libs.bcv)
   api(libs.dokkatoo)
 
   implementation(project(":librarian-core"))
@@ -21,7 +20,7 @@ dependencies {
 
   compileOnly(libs.gradle.api)
   compileOnly(libs.agp)
-  compileOnly(libs.kgp)
+  implementation(libs.kgp.runtime.min)
 
   testImplementation(kotlin("test"))
   testImplementation(gradleTestKit())

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/Librarian.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/Librarian.kt
@@ -4,6 +4,7 @@ import com.gradleup.librarian.gradle.internal.task.registerPublishToGcsTask
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
 
 class Librarian {
   companion object {
@@ -13,8 +14,8 @@ class Librarian {
     }
 
     @Suppress("DEPRECATION")
-    fun module(project: Project) {
-      project.librarianModule()
+    fun module(project: Project, block: AbiValidationExtension.() -> Unit = {}) {
+      project.librarianModule(block)
     }
 
     fun registerGcsTask(

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
@@ -1,14 +1,17 @@
 package com.gradleup.librarian.gradle
 
-import kotlinx.validation.ApiValidationExtension
-import kotlinx.validation.ExperimentalBCVApi
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
-@OptIn(ExperimentalBCVApi::class)
-fun Project.configureBcv(block: ApiValidationExtension.() -> Unit = {}) {
-  pluginManager.apply("org.jetbrains.kotlinx.binary-compatibility-validator")
-  extensions.getByType(ApiValidationExtension::class.java).apply {
-    klib.enabled = true
-    block()
+@OptIn(ExperimentalAbiValidation::class)
+fun Project.configureBcv(block: AbiValidationExtension.() -> Unit = {}) {
+  extensions.getByType(KotlinProjectExtension::class.java).apply {
+      this.extensions.getByName("abiValidation").apply {
+          this as AbiValidationExtension
+          enabled.set(true)
+          block()
+      }
   }
 }

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/dokkatoo.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/dokkatoo.kt
@@ -14,7 +14,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import javax.inject.Inject
 
-val skipProjectIsolationIncompatibleParts = false
+internal val skipProjectIsolationIncompatibleParts = false
 class KdocAggregate(
     val currentVersion: String,
     val olderVersions: List<Coordinates>,

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/dokkatoo.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/dokkatoo.kt
@@ -12,9 +12,9 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
-import java.io.File
 import javax.inject.Inject
 
+val skipProjectIsolationIncompatibleParts = false
 class KdocAggregate(
     val currentVersion: String,
     val olderVersions: List<Coordinates>,

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/generatedVersion.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/generatedVersion.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import java.io.File
 
 internal const val LIBRARIAN_GENERATE_VERSION = "librarianGenerateVersion"
@@ -33,7 +33,7 @@ fun Project.configureGeneratedVersion(packageName: String, pomVersion: String) {
   val versionFileProvider = pluginVersionTaskProvider.flatMap { it.outputDir }
   sourceSet.kotlin.srcDir(versionFileProvider)
 
-  tasks.withType(KotlinCompile::class.java) {
+  tasks.withType(KotlinCompilationTask::class.java) {
     it.dependsOn(pluginVersionTaskProvider)
   }
 }

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/module.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/module.kt
@@ -4,6 +4,7 @@ import com.gradleup.librarian.core.tooling.init.modulePropertiesFilename
 import com.gradleup.librarian.core.tooling.init.rootPropertiesFilename
 import com.gradleup.librarian.gradle.internal.findEnvironmentVariable
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
 import java.util.Properties
 
 internal fun Properties.javaCompatibility(): Int? {
@@ -73,9 +74,11 @@ internal fun Project.moduleProperties(): Properties {
 }
 
 @Deprecated("use Librarian.module() instead.", ReplaceWith("Librarian.module(project)", "import com.gradleup.librarian.gradle.Librarian"))
-fun Project.librarianModule() {
+fun Project.librarianModule(block: AbiValidationExtension.() -> Unit = {}) {
   val rootProperties = rootProperties()
   val moduleProperties = moduleProperties()
+
+  configureBcv(block)
 
   rootProperties.javaCompatibility()?.let {
     configureJavaCompatibility(it)

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/root.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/root.kt
@@ -5,14 +5,8 @@ import nmcp.NmcpAggregationExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 
-internal val skipProjectIsolationIncompatibleParts = false
-
 @Deprecated("use Librarian.root() instead", ReplaceWith("Librarian.root(project)", "import com.gradleup.librarian.gradle.Librarian"))
 fun Project.librarianRoot() {
-  if (!skipProjectIsolationIncompatibleParts) {
-    configureBcv()
-  }
-
   val properties = project.rootProperties()
   val pomMetadata = PomMetadata(properties.kdocArtifactId(), properties)
   val sonatype = Sonatype(project, properties)

--- a/scripts/update-repo.main.kts
+++ b/scripts/update-repo.main.kts
@@ -3,21 +3,10 @@
 @file:Repository("https://repo.maven.apache.org/maven2/")
 @file:Repository("https://storage.googleapis.com/gradleup/m2")
 @file:Repository("https://jitpack.io")
-@file:DependsOn("com.gradleup.librarian:librarian-cli:0.0.11-SNAPSHOT-ba8b5ecfcbda070ecc3b5b95056ee359199552b4")
+@file:DependsOn("com.gradleup.librarian:librarian-cli:0.0.11-SNAPSHOT-0c63531f2132a26ec9e2f7f730ba41d74598e100")
 
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.subcommands
-import com.gradleup.librarian.cli.command.PrepareNextVersion
-import com.gradleup.librarian.cli.command.SetVersion
-
-
-class MainCommand : CliktCommand() {
-    override fun run() {
-    }
-}
-
-MainCommand().subcommands(SetVersion(), PrepareNextVersion {
+updateRepo(args) {
     file("README.md") {
         replacePluginId("com.gradleup.librarian")
     }
-}).main(args)
+}


### PR DESCRIPTION
KGP is now an `implementation` dependency, meaning that you'll need KGP >= 2.2 to run librarian