### PR TITLE
Add headers to getting started doc to make eye-scanning easier

### DIFF
--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -5,20 +5,17 @@ title: Welcome to Librarian
 Librarian is an opinionated toolkit to build Kotlin libraries.
 
 :::note
-This project is work in progress
+This project is work in progress, this documentation itself is work in progress.
+If you have questions, please ask in the `#gradleup` channel in the [Gradle community Slack](https://gradle-community.slack.com/).
 
 :::
 
 Librarian:
 
 * publishes your KMP/Android/JVM libraries to:
-    * Maven Central using [default host](https://central.sonatype.org/publish/publish-guide/#releasing-to-central)
-    * Maven Central using [S01 host](https://central.sonatype.org/publish/publish-guide/#releasing-to-central)
-    * Maven Central using [the central portal API](https://central.sonatype.com/api-doc)
-    * OSS Sonatype snapshots using the default host
-    * OSS Sonatype snapshots using the S01 host
+    * Maven Central releases
+    * Maven Central snapshots 
     * [Google Cloud Storage](https://cloud.google.com/storage?hl=en)
-    * GitHub pages snapshots
 * generates versioned KDoc using [Dokka](https://github.com/Kotlin/dokka)
 * automates your workflows using GitHub actions:
     * pull requests
@@ -29,14 +26,8 @@ Librarian:
 * monitors your binary compatibility using Kotlin Binary Compatibility validator
 * configures Java and Kotlin compatibility
 * ensure your libs can be consumed with maven
-* manages your changelog
 * and more!
 
-This is a lot of things for a single tool, and a lot of opinions too!
-
-Because every lib is different and opinions may differ, Librarian is also shipped as low level libraries that you can use on a case by case basis.
-
-Just want the publishing without the GitHub workflows, use `librarian-publishing`. Just want maven sympathy, use `librarian-maven-sympathy`, etc... For more information, read the [libraries page](libraries.md).
 
 ## Get started
 
@@ -46,49 +37,44 @@ Add the Gradle plugin to your root `build.gradle.kts`:
 
 ```kotlin
 plugins {
-  id("com.gradleup.librarian")
+  id("com.gradleup.librarian").apply(false)
 }
 
 Librarian.root(project)
 ```
 
-### 2/4 Project-specific configuration
+### 2/4 Root project configuration
 
-Add a librarian.root.properties:
+Add a `librarian.root.properties` file to the root of your repository:
 
 ```
-# Maven Central backend to use
-# Valid values: Default, S01, Portal
-sonatype.backend=Default
-
-# Common POM (Project Object Model) information for your repository
-pom.groupId=com.gradleup.librarian
+# Common information for your repository
+pom.groupId=com.example
 pom.version=0.0.7-SNAPSHOT
-pom.description=Librarian
-pom.vcsUrl=https://github.com/gradleup/librarian
-pom.developer=GradleUp authors
-pom.license=MIT License
+pom.description=Cool library
+pom.vcsUrl=https://github.com/example/cool
+pom.developer=Cool library authors
+pom.license=MIT
 
 # Optional: publish to Google Cloud Storage
 gcs.bucket=gradleup
 gcs.prefix=m2
 
-# Optional: configure java compatibility
+# Optional: configure compatibility
 java.compatibility=11 
 kotlin.compatibility=2.0.0
 
-# Optional: publish several versions of the Kdoc (requires them to be already published)
+# Optional: publish older versions of the Kdoc (requires them to be already published)
 kdoc.olderVersions=1.0.0,2.0.0
 ```
 
-### 3/4 Enable it on each library module
+### 3/4 Project specific configuration
 
-Configure librarian in each module:
+Configure librarian in each subproject:
 
 ```kotlin
 // module/build.gradle.kts
 plugins {
-  id("org.jetbrains.kotlin.jvm")
   // no need to add librarian here, it's already on the classpath
 }
 
@@ -117,6 +103,4 @@ Publish your library:
 ./gradlew librarianPublishToMavenSnapshots
 ./gradlew librarianPublishToGcs
 ```
-
-Automate your workflows:
 


### PR DESCRIPTION
I thought it'd be slightly easier to read with a few extra titles, but I won't be mad if you prefer to keep it as is.