### PR TITLE
SemVer: allow PreRelease containing digits, and without a version

### DIFF
--- a/librarian-core/api/librarian-core.api
+++ b/librarian-core/api/librarian-core.api
@@ -46,9 +46,9 @@ public final class com/gradleup/librarian/core/tooling/KeysKt {
 }
 
 public final class com/gradleup/librarian/core/tooling/PreRelease {
-	public fun <init> (Ljava/lang/String;I)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
 	public final fun getName ()Ljava/lang/String;
-	public final fun getVersion ()I
+	public final fun getVersion ()Ljava/lang/Integer;
 }
 
 public final class com/gradleup/librarian/core/tooling/ProcessKt {
@@ -91,9 +91,9 @@ public final class com/gradleup/librarian/core/tooling/SemVer {
 
 public final class com/gradleup/librarian/core/tooling/SemverKt {
 	public static final fun bump (Lcom/gradleup/librarian/core/tooling/SemVer;)Lcom/gradleup/librarian/core/tooling/SemVer;
-	public static final fun copy (Lcom/gradleup/librarian/core/tooling/PreRelease;Ljava/lang/String;I)Lcom/gradleup/librarian/core/tooling/PreRelease;
+	public static final fun copy (Lcom/gradleup/librarian/core/tooling/PreRelease;Ljava/lang/String;Ljava/lang/Integer;)Lcom/gradleup/librarian/core/tooling/PreRelease;
 	public static final fun copy (Lcom/gradleup/librarian/core/tooling/SemVer;IIILcom/gradleup/librarian/core/tooling/PreRelease;Z)Lcom/gradleup/librarian/core/tooling/SemVer;
-	public static synthetic fun copy$default (Lcom/gradleup/librarian/core/tooling/PreRelease;Ljava/lang/String;IILjava/lang/Object;)Lcom/gradleup/librarian/core/tooling/PreRelease;
+	public static synthetic fun copy$default (Lcom/gradleup/librarian/core/tooling/PreRelease;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/gradleup/librarian/core/tooling/PreRelease;
 	public static synthetic fun copy$default (Lcom/gradleup/librarian/core/tooling/SemVer;IIILcom/gradleup/librarian/core/tooling/PreRelease;ZILjava/lang/Object;)Lcom/gradleup/librarian/core/tooling/SemVer;
 	public static final fun next (Lcom/gradleup/librarian/core/tooling/SemVer;)Lcom/gradleup/librarian/core/tooling/SemVer;
 	public static final fun nextMajor (Lcom/gradleup/librarian/core/tooling/SemVer;)Lcom/gradleup/librarian/core/tooling/SemVer;

--- a/librarian-core/src/main/kotlin/com/gradleup/librarian/core/tooling/semver.kt
+++ b/librarian-core/src/main/kotlin/com/gradleup/librarian/core/tooling/semver.kt
@@ -2,7 +2,7 @@ package com.gradleup.librarian.core.tooling
 
 class PreRelease(
     val name: String,
-    val version: Int,
+    val version: Int?,
 )
 
 /**
@@ -100,7 +100,10 @@ class SemVer(
     return buildString {
       append("$major.$minor.$patch")
       if (preRelease != null) {
-        append("-${preRelease.name}.${preRelease.version}")
+        append("-${preRelease.name}")
+        if (preRelease.version != null) {
+          append(".${preRelease.version}")
+        }
       }
       if (isSnapshot) {
         append("-SNAPSHOT")
@@ -110,6 +113,7 @@ class SemVer(
 }
 
 internal fun PreRelease?.compareTo(other: PreRelease?): Int {
+  // v1.0.0-beta < v1.0.0
   return if (this == null && other == null) {
     0
   } else if (this == null) {
@@ -117,13 +121,23 @@ internal fun PreRelease?.compareTo(other: PreRelease?): Int {
   } else if (other == null) {
     -1
   } else {
+    // v1.0.0-beta01 < v1.0.0-beta02
     // XXX: should we handle non-lexicographic order here? (-dev could be lower than -alpha, etc...)
     val ret = name.compareTo(other.name)
     if (ret != 0) {
       return ret
     }
 
-    version.compareTo(other.version)
+    // v1.0.0-beta < v1.0.0-beta.1
+    if (version == null && other.version == null) {
+      0
+    } else if (version == null) {
+      -1
+    } else if (other.version == null) {
+      1
+    } else {
+      version.compareTo(other.version)
+    }
   }
 }
 
@@ -145,7 +159,7 @@ fun SemVer.copy(
 
 fun PreRelease.copy(
     name: String = this.name,
-    version: Int = this.version
+    version: Int? = this.version
 ): PreRelease {
   return PreRelease(name, version)
 }
@@ -167,7 +181,7 @@ fun SemVer.nextMajor(): SemVer {
 
 fun SemVer.nextPrerelease(): SemVer {
   require(preRelease != null) { "Cannot bump prerelease on non-prerelease version" }
-  return copy(preRelease = preRelease.copy(version = preRelease.version + 1))
+  return copy(preRelease = preRelease.copy(version = (preRelease.version ?: 0) + 1))
 }
 
 /**
@@ -187,7 +201,7 @@ fun SemVer.next(): SemVer {
       copy(isSnapshot = false)
     }
     preRelease != null -> {
-      copy(preRelease = preRelease.copy(version = preRelease.version + 1), isSnapshot = false)
+      copy(preRelease = preRelease.copy(version = (preRelease.version ?: 0) + 1), isSnapshot = false)
     }
     else -> {
       copy(patch = patch + 1, isSnapshot = false)
@@ -223,11 +237,11 @@ fun String.semVerOrNull(): SemVer? {
       return null
     }
     rem = rem.substring(1)
-    val regex2 = Regex("([a-zA-Z]+)\\.([0-9]+)")
+    val regex2 = Regex("([a-zA-Z][a-zA-Z0-9]*)(\\.([0-9]+))?")
     val result2 = regex2.matchEntire(rem) ?: return null
 
-    val v = result2.groupValues[2].toIntOrNull() ?: return null
-    preRelease = PreRelease(result2.groupValues[1], v)
+    val preReleaseVersion = result2.groupValues.getOrNull(3)?.toIntOrNull()
+    preRelease = PreRelease(result2.groupValues[1], preReleaseVersion)
   }
   return SemVer(
       major,

--- a/librarian-core/src/test/kotlin/SemVerTest.kt
+++ b/librarian-core/src/test/kotlin/SemVerTest.kt
@@ -1,7 +1,10 @@
 import com.gradleup.librarian.core.tooling.semVerOrNull
+import com.gradleup.librarian.core.tooling.semVerOrThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SemVerTest {
   @Test
@@ -40,5 +43,16 @@ class SemVerTest {
       assertEquals("alpha", preRelease?.name)
       assertEquals(0, preRelease?.version)
     }
+    "2.4.0-Beta2".semVerOrNull().apply {
+      assertNotNull(this)
+      assertEquals(2, major)
+      assertEquals(4, minor)
+      assertEquals(0, patch)
+      assertEquals(false, isSnapshot)
+      assertEquals("Beta2", preRelease?.name)
+      assertEquals(null, preRelease?.version)
+    }
+    assertEquals("2.4.0-Beta2", "2.4.0-Beta2".semVerOrThrow().toString())
+    assertTrue("2.4.0-Beta2".semVerOrThrow() < "2.4.0-Beta2.1".semVerOrThrow())
   }
 }


### PR DESCRIPTION
Noticed that using Kotlin `2.4.0-Beta2` would throw when configuring BCV, even though it is a valid SemVer version.

(Unfortunately ABI breaking, hopefully not a big deal.)

(Of course this would be avoided if JetBrains were naming their version `2.4.0-beta.2` as God intended 😂)