### PR TITLE
Compatibility with Kotlin 2.4.0-Beta2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ jsonpath = "com.eygraber:jsonpathkt-kotlinx:3.0.2"
 jsonpathkt = "com.eygraber:jsonpathkt-kotlinx:3.0.2"
 kgp220 = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"
 kgp2320 = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20"
+kgp240 = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0-Beta2"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kgp" }
 ksp-gradle-plugin = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.3"
 librarian-gradle-plugin = "com.gradleup.librarian:librarian-gradle-plugin:0.2.2-SNAPSHOT-c2127df7d03b2946fc025bf67d31cac3e2c5a397"

--- a/librarian-core/src/main/kotlin/com/gradleup/librarian/core/tooling/semver.kt
+++ b/librarian-core/src/main/kotlin/com/gradleup/librarian/core/tooling/semver.kt
@@ -7,7 +7,12 @@ class PreRelease(
 
 /**
  *
- * A variation of the traditional semantic versioning specification to support `-SNAPSHOT` and prerelease versions.
+ * A variation of the traditional semantic versioning specification to support `-SNAPSHOT` and prerelease versions like:
+ *
+ * - 1.0.0
+ * - 1.0.0-SNAPSHOT
+ * - 1.0.0-rc.0
+ * - 1.0.0.rc-0-SNAPSHOT
  *
  * ```
  * <valid semver> ::= <version core>

--- a/librarian-gradle-plugin/build.gradle.kts
+++ b/librarian-gradle-plugin/build.gradle.kts
@@ -50,7 +50,8 @@ val mainCompilation = kotlin.target.compilations.getByName("main")
 
 mapOf(
   "220" to setOf(libs.kgp220),
-  "2320" to setOf(libs.kgp2320)
+  "2320" to setOf(libs.kgp2320),
+  "240" to setOf(libs.kgp240)
 ).forEach {
   val compilation = kotlin.target.compilations.create("kgp-${it.key}")
 

--- a/librarian-gradle-plugin/src/kgp-240/kotlin/com/gradleup/librarian/internal/bcv240.kt
+++ b/librarian-gradle-plugin/src/kgp-240/kotlin/com/gradleup/librarian/internal/bcv240.kt
@@ -1,0 +1,35 @@
+@file:OptIn(ExperimentalAbiValidation::class)
+
+package com.gradleup.librarian.internal
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
+fun Project.configureBcv240(
+  excludePatterns: List<String> = emptyList(),
+) {
+  extensions.getByType(KotlinProjectExtension::class.java).apply {
+    abiValidation {
+      it.filters {
+        it.exclude.byNames.addAll(excludePatterns)
+      }
+    }
+
+    /**
+     * Compatibility tasks to not break the brain muscle
+     */
+    tasks.register("apiDump") {
+      it.dependsOn("updateKotlinAbi")
+      it.doLast {
+        println("`apiDump` is deprecated. Use `updateKotlinAbi` instead")
+      }
+    }
+    tasks.register("apiCheck") {
+      it.dependsOn("checkKotlinAbi")
+      it.doLast {
+        println("`apiCheck` is deprecated. Use `updateKotlinAbi` instead")
+      }
+    }
+  }
+}

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
@@ -14,11 +14,11 @@ fun Project.configureBcv(
   excludePatterns: List<String> = emptyList(),
 ) {
   // See https://kotlinlang.org/docs/whatsnew2320.html#improvements-to-binary-compatibility-validation-in-kgp
-  val kgpVersion = this@configureBcv.getKotlinPluginVersion().semVerOrThrow()
+  val kgpVersion = this@configureBcv.getKotlinPluginVersion()
 
   when {
-    kgpVersion >= "2.3.20".semVerOrThrow() -> configureBcv2320(excludePatterns)
-    kgpVersion >= "2.2.0".semVerOrThrow() -> configureBcv220(excludePatterns)
+    kgpVersion >= "2.3.20" -> configureBcv2320(excludePatterns)
+    kgpVersion >= "2.2.0" -> configureBcv220(excludePatterns)
     else -> {
       if (warnIfMissing) {
         println("Librarian: BCV is only configured by default if using KGP 2.2+ (currently detected is '${getKotlinPluginVersion()}'). Set bcv.warn=false in your librarian.root.properties file to remove this warning.")

--- a/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
+++ b/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/bcv.kt
@@ -5,6 +5,7 @@ package com.gradleup.librarian.gradle
 import com.gradleup.librarian.core.tooling.semVerOrThrow
 import com.gradleup.librarian.internal.configureBcv220
 import com.gradleup.librarian.internal.configureBcv2320
+import com.gradleup.librarian.internal.configureBcv240
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
@@ -17,6 +18,7 @@ fun Project.configureBcv(
   val kgpVersion = this@configureBcv.getKotlinPluginVersion()
 
   when {
+    kgpVersion >= "2.4.0" -> configureBcv240(excludePatterns)
     kgpVersion >= "2.3.20" -> configureBcv2320(excludePatterns)
     kgpVersion >= "2.2.0" -> configureBcv220(excludePatterns)
     else -> {


### PR DESCRIPTION
Our Semver cannot handle versions like `2.4.0-Beta2`

See https://github.com/GradleUp/librarian/pull/127